### PR TITLE
chore: Adding feedback request to contributors bot

### DIFF
--- a/lib/add-contributor.js
+++ b/lib/add-contributor.js
@@ -27,9 +27,9 @@ async function addContributor({
         if (contributorEmail) {
             const emailComponents = contributorEmail.split('@')
             const maskedEmail = `${emailComponents[0].slice(0, 2)}*******@${emailComponents[1].slice(0, 2)}*******.***`
-            merchNotification = `@${who} As a thank you, we sent you an email at ${maskedEmail} with a voucher for [our merch](https://merch.posthog.com/)! If you don't have access to that inbox, message hey@posthog.com and we'll sort something out. We'd also love to know what you think of PostHog, so please [share your feedback with us](https://www.g2.com/g2gives/girls-who-code-pillar-2022/and/posthog).`
+            merchNotification = `@${who} As a thank you, we sent you an email at ${maskedEmail} with a voucher for [our merch](https://merch.posthog.com/)! If you don't have access to that inbox, message hey@posthog.com and we'll sort something out. If you have a moment, we'd also love to know [what you think about PostHog!](https://www.g2.com/g2gives/girls-who-code-pillar-2022/and/posthog)`
         } else {
-            merchNotification = `@${who} As a thank you, we'd like to gift you a voucher for [our merch](https://merch.posthog.com/) – just email hey@posthog.com to get it! We'd also love to know what you think of PostHog, so please [share your feedback with us](https://www.g2.com/g2gives/girls-who-code-pillar-2022/and/posthog).
+            merchNotification = `@${who} As a thank you, we'd like to gift you a voucher for [our merch](https://merch.posthog.com/) – just email hey@posthog.com to get it! If you have a moment, we'd also love to know [what you think about PostHog!](https://www.g2.com/g2gives/girls-who-code-pillar-2022/and/posthog)
       `
         }
     }

--- a/lib/add-contributor.js
+++ b/lib/add-contributor.js
@@ -27,9 +27,9 @@ async function addContributor({
         if (contributorEmail) {
             const emailComponents = contributorEmail.split('@')
             const maskedEmail = `${emailComponents[0].slice(0, 2)}*******@${emailComponents[1].slice(0, 2)}*******.***`
-            merchNotification = `@${who} As a thank you, we sent you an email at ${maskedEmail} with a voucher for [our merch](https://merch.posthog.com/)! If you don't have access to that inbox, message hey@posthog.com and we'll sort something out.`
+            merchNotification = `@${who} As a thank you, we sent you an email at ${maskedEmail} with a voucher for [our merch](https://merch.posthog.com/)! If you don't have access to that inbox, message hey@posthog.com and we'll sort something out. We'd also love to know what you think of PostHog, so please [share your feedback with us](https://www.g2.com/g2gives/girls-who-code-pillar-2022/and/posthog).`
         } else {
-            merchNotification = `@${who} As a thank you, we'd like to gift you a voucher for [our merch](https://merch.posthog.com/) – just email hey@posthog.com to get it!
+            merchNotification = `@${who} As a thank you, we'd like to gift you a voucher for [our merch](https://merch.posthog.com/) – just email hey@posthog.com to get it! We'd also love to know what you think of PostHog, so please [share your feedback with us](https://www.g2.com/g2gives/girls-who-code-pillar-2022/and/posthog).
       `
         }
     }


### PR DESCRIPTION
I've seen good response rates asking contributors for feedback via G2. 

However, this is tricky as it's manual and not all of them are in the Slack. 

Solution: Add a simple request to the bot, which tags them when recognizing their work. 

Added bonus: +1 to the number of repos I have touched at PostHog so far!